### PR TITLE
Add a parameter to cloud init to be able to set the remote

### DIFF
--- a/aeriscloud/cli/cloud/organization.py
+++ b/aeriscloud/cli/cloud/organization.py
@@ -161,7 +161,8 @@ def list():
 
 @cli.command(cls=Command)
 @click.argument('name')
-def init(name):
+@click.argument('repository', required=False)
+def init(name, repository):
     """
     Initialize a new organization.
     """
@@ -196,6 +197,9 @@ def init(name):
     success("The %s organization has been created." % name)
 
     run_galaxy_install(name)
+
+    if repository:
+        vgit("remote", "add", "origin", repository)
 
 
 @cli.command(cls=Command)


### PR DESCRIPTION
See #6

This helps setting a remote when you are initializing an organization.

``` bash
cloud -v organization init custom git@github.com:Custom/repo.git
# edit your files
git add .
git commit ...
git push ...
```
