### PR TITLE
Don't run the configuration assistant during the install process

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -447,8 +447,7 @@ fi
 
 echo
 
-# Show the installed version of stuff, will also trigger the config assistant
-# if necessary
-"${INSTALL_DIR}/venv/bin/aeris" version
+# Show the installed version of stuff
+AC_NO_ASSISTANT=1 "${INSTALL_DIR}/venv/bin/aeris" version
 
 echo -e "\nInstallation finished successfully\n"


### PR DESCRIPTION
As the configuration assistant is no longer run during the install process,
you can now configure AerisCloud using `aeris config` without having to run the assistant at all.

The install process can now be:
- clone
- make install
- run a script using aeris config which defines all the settings for your company (so that everyone has the same config)
- run the assistant for the user-specific config (github integration, etc)
