### PR TITLE
Provision all inventory files in a directory

### DIFF
--- a/aeriscloud/ansible.py
+++ b/aeriscloud/ansible.py
@@ -144,7 +144,7 @@ def get_job_file(job):
 
 def get_inventory_file(inventory):
     inv_file = os.path.join(inventory_path, inventory)
-    if not os.path.isfile(inv_file):
+    if not os.path.exists(inv_file):
         raise IOError('Inventory %s does not exists' % inventory)
     return inv_file
 


### PR DESCRIPTION
This PR allows provisioning all inventory files in a directory.

For example, in your inventory directory, you have have a project with multiple inventory files, each specifying the same setup in different datacenters:

```
my-org/projectA/eu-west-1
my-org/projectA/ap-northeast-1
my-org/projectA/us-east-1
```

Withou this PR, you provision each individually:

```
cloud provision my-org/production my-org/projectA/eu-west-1
cloud provision my-org/production my-org/projectA/ap-northeast-1
cloud provision my-org/production my-org/projectA/us-east-1
```

With this PR, you can do the above or all of them at once:

```
cloud provision my-org/production my-org/projectA
```
