### PR TITLE
Use ansible-lint 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ Sphinx~=1.2
 watchdog~=0.8
 git+https://github.com/christopherobin/python-subprocess32.git#egg=subprocess32
 git+https://github.com/dominis/ansible-shell.git#egg=ansible-shell
-git+https://github.com/willthames/ansible-lint.git#egg=ansible-lint
+git+https://github.com/willthames/ansible-lint.git@d959090a3e15d978039c81252fc2bfcb2488f8a2#egg=ansible-lint


### PR DESCRIPTION
Use the last commit of https://github.com/willthames/ansible-lint/tree/v2.7
It doesn't support Ansible 2.x but doesn't require to rewrite the rules.
#20 is no longer required.
