### PR TITLE
The bucket name for boxes might not be a resolvable URL

### DIFF
--- a/aeriscloud/cli/aeris/box.py
+++ b/aeriscloud/cli/aeris/box.py
@@ -63,7 +63,8 @@ def _generate_meta(metadata, basebox, box, version):
             metadata[basebox]['short_description'] = \
                 'A prepackaged %s box.' % box
 
-    url = 'http://%s/%s-%s.box' % (basebox_bucket(), basebox, version)
+    url = 'http://%s.s3.amazonaws.com/%s-%s.box' % \
+          (basebox_bucket(), basebox, version)
     metadata[basebox]['versions'].append({
         'status': 'active',
         'version': version,
@@ -122,12 +123,15 @@ def generate(output_json, output_path):
 
     click.secho(
         'The metadata files have been saved in the %s directory.\n'
-        'You can upload them to s3 with the following command:\n'
+        'You can upload them to s3 with one of the following commands:\n'
         % output_path,
         fg='green')
 
     click.echo('s3cmd put --recursive %s -m'
                '\"application/json\" s3://%s/'
+               % (output_path, basebox_bucket()))
+    click.echo('aws s3 sync --content-type \"application/json\" '
+               '%s s3://%s/meta/'
                % (output_path, basebox_bucket()))
 
 

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -42,7 +42,9 @@ If your organization has it's own basebox repository for Vagrant, it should be
 set here so that the :ref:`aeris-init` command might be able to set it in
 your projects. See :ref:`aeris-box` ::
 
-  config.basebox_bucket = https://my-org.tld/baseboxes/meta
+  config.basebox_bucket = organization-boxes
+
+*Note:* This is the AWS S3 bucket name. The required URLs will automatically be generated from that name.
 
 .. _config-raven:
 


### PR DESCRIPTION
Until now, the bucket name for the boxes was of the following syntax: `boxes.org.tld` and the url `http://boxes.org.tld` was actually pointing to `http://boxes.org.tld.s3-website-region.amazonaws.com`.

By changing the code to expect only a bucket name, it's now possible to work without a valid URL.
`bucket.s3.amazonaws.com` will redirect to `bucket.s3-website-region.amazonaws.com` and the boxes can be downloaded from the S3 Website endpoint URL.
