### PR TITLE
cloud inventory list should list inventory files by following symlinks

### DIFF
--- a/aeriscloud/ansible.py
+++ b/aeriscloud/ansible.py
@@ -158,7 +158,7 @@ def get_inventory_list():
     """
     inventory_list = []
     for dirname, dirnames, filenames \
-            in os.walk(inventory_path):
+            in os.walk(inventory_path, followlinks=True):
         if os.sep + '.git' in dirname:
             continue
 


### PR DESCRIPTION
Without that, inventories managed as symlinks are not listed and autocomplete doesn't work.
