### PR TITLE
Pin sh package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ prompt-toolkit==0.31
 python-slugify~=1.0
 raven~=5.2.0
 semver~=2.0
-sh~=1.11
+sh==1.11
 Sphinx~=1.2
 watchdog~=0.8
 git+https://github.com/christopherobin/python-subprocess32.git#egg=subprocess32


### PR DESCRIPTION
The latest version of sh (`1.12.1`) introduced a new behavior for the special kwarg `_out_bufsize`.
This breaks several commands:
```
$ venv/bin/cloud -v organization install
2016-12-12 14:36:44,108 [ERROR] cli.helpers: uncaught exception while running subcommand "None"
Traceback (most recent call last):
  File "/Users/emilien/Dev/AerisCloud/aeriscloud/cli/helpers.py", line 106, in invoke
    super(AerisCLI, self).invoke(ctx)
  File "/Users/emilien/Dev/AerisCloud/venv/lib/python2.7/site-packages/click/core.py", line 931, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/Users/emilien/Dev/AerisCloud/venv/lib/python2.7/site-packages/click/core.py", line 970, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
  File "/Users/emilien/Dev/AerisCloud/aeriscloud/cli/helpers.py", line 92, in get_command
    eval(code, ns, ns)
  File "/Users/emilien/Dev/AerisCloud/aeriscloud/cli/cloud/organization.py", line 28, in <module>
    vgit = git.bake(_out=sys.stdout, _out_bufsize=0, _err_to_out=True)
  File "/Users/emilien/Dev/AerisCloud/venv/lib/python2.7/site-packages/sh.py", line 1128, in bake
    call_args, kwargs = self._extract_call_args(kwargs)
  File "/Users/emilien/Dev/AerisCloud/venv/lib/python2.7/site-packages/sh.py", line 1118, in _extract_call_args
    raise TypeError("Invalid special arguments:\n\n%s\n" % exc_msg)
TypeError: Invalid special arguments:

  ('out', 'out_bufsize'): Can't specify an out bufsize if the out target is a pipe or TTY

error: an internal exception caused "cloud" to exit unexpectedly
```