### PR TITLE
install: fix fail task to work with ansible 2.1

### DIFF
--- a/scripts/install/roles/vagrant/tasks/main.yml
+++ b/scripts/install/roles/vagrant/tasks/main.yml
@@ -45,7 +45,8 @@
     which vagrant 2>&1 >/dev/null
   register: vagrant_installed
 
-- fail: "Vagrant must be installed"
+- fail:
+    msg: "Vagrant must be installed"
   when: vagrant_installed|failed
 
 - name: Retrieve installed plugins


### PR DESCRIPTION
Fixes this error:
```
The error appears to have been in '/opt/aeriscloud/scripts/install/roles/vagrant/tasks/main.yml': line 48, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- fail: "Vagrant must be installed"
  ^ here
```

When installing with:
```
sudo git clone https://github.com/aeriscloud/aeriscloud.git /opt/aeriscloud
sudo chown -R vagrant /opt/aeriscloud
cd /opt/aeriscloud
export AC_NO_ASSISTANT=1
make install
```
