### PR TITLE
`_fixup_perms is deprecated. Use _fixup_perms2 instead.`

### DIFF
--- a/ansible/plugins/actions/aeriscloud_service.py
+++ b/ansible/plugins/actions/aeriscloud_service.py
@@ -107,7 +107,7 @@ class ActionModule(ActionBase):
                 xfered = self._transfer_data(self._connection._shell.join_path(tmp, 'source'), resultant)
 
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms(xfered, remote_user)
+                self._fixup_perms2([xfered], remote_user)
 
                 # run the copy module
                 new_module_args.update(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.2.3.0
+ansible==2.3.1.0
 appdirs~=1.4
 arrow~=0.5
 click~=3.3


### PR DESCRIPTION
With PR https://github.com/AerisCloud/AerisCloud/pull/40 , fixes this error with Ansible 2.3.1:

```
[DEPRECATION WARNING]: _fixup_perms is deprecated. Use _fixup_perms2 instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
fatal: [node1.couchbase1]: FAILED! => {"failed": true, "msg": "_fixup_perms with recursive=True (the default) is no longer supported. Use _fixup_perms2 if support for previous releases is not required. Otherwise use fixup_perms with recursive=False."}
```
